### PR TITLE
Parsing .siq files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ piston = "0.49.0"
 piston2d-graphics = "0.35.0"
 pistoncore-glutin_window = "0.63.0"
 piston2d-opengl_graphics = "0.70.0"
+
+serde = { version = "1.0", features = [ "derive" ] }
+quick-xml = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ piston2d-opengl_graphics = "0.70.0"
 
 serde = { version = "1.0", features = [ "derive" ] }
 quick-xml = "0.17"
+zip = "0.5.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 authors = ["barsoosayque <shtoshich@gmail.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 piston = "0.49.0"
 piston2d-graphics = "0.35.0"
@@ -13,5 +11,5 @@ pistoncore-glutin_window = "0.63.0"
 piston2d-opengl_graphics = "0.70.0"
 
 serde = { version = "1.0", features = [ "derive" ] }
-quick-xml = "0.17"
+quick-xml = { version = "0.17", features = [ "serialize" ] }
 zip = "0.5.4"

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,3 +1,14 @@
+#![cfg(feature = "serialize")]
+extern crate quick_xml;
+extern crate serde; 
+
+use PartialEq;
+use serde::Deserialize;
+// use quick_xml::DeError;
+use quick_xml::de::{from_str, DeError};
+// use quick_xml::se::to_string;
+
+#[derive(Debug, Deserialize, PartialEq)]
 pub struct Package {
     id: String,
     name: String,
@@ -13,6 +24,7 @@ pub struct Package {
     info: Info
 }
 
+#[derive(Debug, Deserialize, PartialEq)]
 pub struct Info {
     comments: String, 
     extension: String,
@@ -20,6 +32,7 @@ pub struct Info {
     sources: Vec<String>
 }
 
+#[derive(Debug, Deserialize, PartialEq)]
 pub struct Round {
     name: String,
     variant: String, // fixme: original name "type"
@@ -27,22 +40,25 @@ pub struct Round {
     themes: Vec<Theme>
 }
 
+#[derive(Debug, Deserialize, PartialEq)]
 pub struct Theme {
     name: String,
-    questions: Vec<Question>
+    questions: Vec<Question>,
     info: Info
 }
 
+#[derive(Debug, Deserialize, PartialEq)]
 pub struct Question {
     price: usize, 
     scenario: Vec<Atom>, 
     right: Vec<String>, 
     wrong: Vec<String>, 
-    variant: String // fixme: original name "type"
+    variant: String, // fixme: original name "type"
     info: Info
 }
 
-pub enum Atom {
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Atom {
     time: Option<f64>,
     variant: String // fixme: original name "type"
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -4,9 +4,7 @@ extern crate serde;
 
 use PartialEq;
 use serde::Deserialize;
-// use quick_xml::DeError;
 use quick_xml::de::{from_str, DeError};
-// use quick_xml::se::to_string;
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Package {

--- a/src/package.rs
+++ b/src/package.rs
@@ -81,13 +81,13 @@ pub struct Question {
     pub right: Right,
     pub wrong: Option<Wrong>,
     #[serde(rename = "type", default)]
-    pub variant: Option<Variant>, 
+    pub variant: Option<Variant>,
     pub info: Option<Info>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Variant {
-    pub name: String
+    pub name: String,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -120,7 +120,7 @@ pub struct Atom {
     #[serde(rename = "type", default)]
     pub variant: Option<String>,
     #[serde(rename = "$value")]
-    pub body: Option<String>
+    pub body: Option<String>,
 }
 
 impl Package {
@@ -132,7 +132,7 @@ impl Package {
         xml.read_to_string(&mut contents).unwrap();
 
         return Package::parse(&contents)
-            .map_err(|e| std::io::Error::new(ErrorKind::InvalidData, e))
+            .map_err(|e| std::io::Error::new(ErrorKind::InvalidData, e));
     }
 
     fn parse(xml: &String) -> Result<Package, DeError> {

--- a/src/package.rs
+++ b/src/package.rs
@@ -2,9 +2,9 @@ extern crate quick_xml;
 extern crate serde;
 
 use std::fs::File;
-use std::path::Path;
 use std::io::prelude::*;
 use std::io::ErrorKind;
+use std::path::Path;
 use PartialEq;
 
 use quick_xml::de::{from_str, DeError};
@@ -12,59 +12,116 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Package {
-    id: String,
-    name: String,
-    version: String,
-    date: Option<String>,
-    difficulty: Option<u8>,
-    language: Option<String>,
-    logo: Option<String>,
-    publisher: Option<String>,
-    restriciton: Option<String>,
-    rounds: Vec<Round>,
-    tags: Vec<String>,
-    info: Info,
+    pub id: String,
+    pub name: Option<String>,
+    pub version: String,
+    pub date: Option<String>,
+    pub difficulty: Option<u8>,
+    pub language: Option<String>,
+    pub logo: Option<String>,
+    pub publisher: Option<String>,
+    pub restriciton: Option<String>,
+    pub rounds: Rounds,
+    pub tags: Option<Vec<String>>,
+    pub info: Info,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Info {
-    comments: String,
-    extension: String,
-    authors: Vec<String>,
-    sources: Vec<String>,
+    pub comments: Option<String>,
+    pub extension: Option<String>,
+    pub authors: Authors,
+    pub sources: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Authors {
+    #[serde(rename = "author", default)]
+    pub authors: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Rounds {
+    #[serde(rename = "round", default)]
+    pub rounds: Vec<Round>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Round {
-    name: String,
-    variant: String, // fixme: original name "type"
-    info: Info,
-    themes: Vec<Theme>,
+    pub name: String,
+    #[serde(rename = "type", default)]
+    pub variant: Option<String>,
+    pub info: Option<Info>,
+    pub themes: Themes,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Themes {
+    #[serde(rename = "theme", default)]
+    pub themes: Vec<Theme>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Theme {
-    name: String,
-    questions: Vec<Question>,
-    info: Info,
+    pub name: String,
+    pub questions: Questions,
+    pub info: Option<Info>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Questions {
+    #[serde(rename = "question", default)]
+    pub questions: Vec<Question>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Question {
-    price: usize,
-    scenario: Vec<Atom>,
-    right: Vec<String>,
-    wrong: Vec<String>,
-    variant: String, // fixme: original name "type"
-    info: Info,
+    pub price: usize,
+    pub scenario: Scenario,
+    pub right: Right,
+    pub wrong: Option<Wrong>,
+    #[serde(rename = "type", default)]
+    pub variant: Option<Variant>, 
+    pub info: Option<Info>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Variant {
+    pub name: String
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Scenario {
+    #[serde(rename = "atom", default)]
+    pub atoms: Vec<Atom>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Right {
+    #[serde(rename = "answer", default)]
+    pub answers: Vec<Answer>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Wrong {
+    #[serde(rename = "answer", default)]
+    pub answers: Vec<Answer>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Answer {
+    #[serde(rename = "$value")]
+    pub body: Option<String>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Atom {
-    time: Option<f64>,
-    variant: String, // fixme: original name "type"
+    pub time: Option<f64>,
+    #[serde(rename = "type", default)]
+    pub variant: Option<String>,
+    #[serde(rename = "$value")]
+    pub body: Option<String>
 }
-
 
 impl Package {
     pub fn open(path: &Path) -> Result<Package, std::io::Error> {

--- a/src/package.rs
+++ b/src/package.rs
@@ -124,7 +124,7 @@ pub struct Atom {
 }
 
 impl Package {
-    pub fn open(path: &Path) -> Result<Package, std::io::Error> {
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Package, std::io::Error> {
         let package_file = File::open(path)?;
         let mut zip = zip::ZipArchive::new(package_file)?;
         let mut xml = zip.by_name("content.xml")?;

--- a/src/package.rs
+++ b/src/package.rs
@@ -131,13 +131,8 @@ impl Package {
         let mut contents = String::new();
         xml.read_to_string(&mut contents).unwrap();
 
-        match Package::parse(&contents) {
-            Ok(package) => Ok(package),
-            Err(e) => {
-                let error = std::io::Error::new(ErrorKind::InvalidData, e);
-                Err(error)
-            }
-        }
+        return Package::parse(&contents)
+            .map_err(|e| std::io::Error::new(ErrorKind::InvalidData, e))
     }
 
     fn parse(xml: &String) -> Result<Package, DeError> {

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,10 +1,11 @@
-#![cfg(feature = "serialize")]
 extern crate quick_xml;
-extern crate serde; 
+extern crate serde;
 
+use std::fs::File;
 use PartialEq;
-use serde::Deserialize;
+
 use quick_xml::de::{from_str, DeError};
+use serde::Deserialize;
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Package {
@@ -19,44 +20,45 @@ pub struct Package {
     restriciton: Option<String>,
     rounds: Vec<Round>,
     tags: Vec<String>,
-    info: Info
+    info: Info,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Info {
-    comments: String, 
+    comments: String,
     extension: String,
     authors: Vec<String>,
-    sources: Vec<String>
+    sources: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Round {
     name: String,
     variant: String, // fixme: original name "type"
-    info: Info, 
-    themes: Vec<Theme>
+    info: Info,
+    themes: Vec<Theme>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Theme {
     name: String,
     questions: Vec<Question>,
-    info: Info
+    info: Info,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Question {
-    price: usize, 
-    scenario: Vec<Atom>, 
-    right: Vec<String>, 
-    wrong: Vec<String>, 
+    price: usize,
+    scenario: Vec<Atom>,
+    right: Vec<String>,
+    wrong: Vec<String>,
     variant: String, // fixme: original name "type"
-    info: Info
+    info: Info,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Atom {
     time: Option<f64>,
-    variant: String // fixme: original name "type"
+    variant: String, // fixme: original name "type"
 }
+


### PR DESCRIPTION
Подключил [serde](https://github.com/serde-rs/serde) для сериализации данных, [quick-xml](https://github.com/tafia/quick-xml) для парсинг xml и [zip-rs](https://github.com/mvdnes/zip-rs) для вскрытия `.siq` файлов.

Сериализация `content.xml` в `*.siq` пакетах выглядит уродливо, есть ненужный уровень вложенности из-за схемы данных. Думаю, что можно замутить добавить еще один уровень абсатркации, чтобы утилизировать мощность системы типов, но пока good enough is good enough. 

Еще думаю, что стоит нашлёпать тесты на парсинг пакетов. Я тестировал через [slamjam2.zip](https://github.com/barsoosayque/opensi/files/4178023/slamjam2.zip) (zip потому что Github не поддерживат `.siq` формат). Но это в отдельный PR. 

Код для отладки (`for round in package.rounds.rounds { ... }`) я думаю заимплементить как `Display` для `Package`. Могу в этом PR докинуть, могу в другом.

 