### PR TITLE
UI для редактора паков

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Install GTK
+      run: sudo apt-get install libgtk-3-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ piston2d-opengl_graphics = "0.70.0"
 serde = { version = "1.0", features = [ "derive" ] }
 quick-xml = { version = "0.17", features = [ "serialize" ] }
 zip = "0.5.4"
+
+gtk = "^0.8.0"
+relm = "^0.19.0"
+relm-derive = "^0.19.0"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,29 @@
 # opensi 
+
 ![Rust](https://github.com/snpefk/opensi/workflows/Rust/badge.svg)
 
 Open SI Game - реализация популярной телеигры на Rust
 
-# Пакеты с игрой 
+## Пакеты с игрой
+
 opensi совместимыми пакетим формата `*.siq` из популярной реализации "Своей игры" - [SiGame](https://vladimirkhil.com/si/game)
+
+## Разработка
+
+Редактор зависит от GTK, поэтому перед разработкой стоит [установить](http://gtk-rs.org/docs/requirements.html) **GTK+**, **GLib** и **Cairo**
+
+### Debian & Ubuntu
+
+```shell
+sudo apt-get install libgtk-3-dev
+```
+
+### Fedora
+
+```shell
+sudo dnf install gtk3-devel glib2-devel
+
+### Fedora 21 and earlier
+sudo yum install gtk3-devel glib2-devel
+
+```

--- a/src/bin/editor.rs
+++ b/src/bin/editor.rs
@@ -1,0 +1,74 @@
+use gtk::prelude::*;
+use gtk::Orientation::Vertical;
+use gtk::{Inhibit, WidgetExt, Window, WindowType};
+use relm::{connect, Relm, Update, Widget};
+use relm_derive::Msg;
+
+struct Model {}
+
+#[derive(Msg)]
+enum Msg {
+    Quit,
+}
+
+// Create the structure that holds the widgets used in the view.
+#[derive(Clone)]
+struct Widgets {
+    window: Window,
+}
+
+struct Win {
+    model: Model,
+    widgets: Widgets,
+}
+
+impl Update for Win {
+    type Model = Model;
+    type ModelParam = ();
+    type Msg = Msg;
+
+    fn model(_: &Relm<Self>, _: ()) -> Model {
+        Model {}
+    }
+
+    fn update(&mut self, event: Msg) {
+        match event {
+            Msg::Quit => gtk::main_quit(),
+        }
+    }
+}
+
+impl Widget for Win {
+    type Root = Window;
+
+    fn root(&self) -> Self::Root {
+        self.widgets.window.clone()
+    }
+
+    fn view(relm: &Relm<Self>, model: Self::Model) -> Self {
+        let window = Window::new(WindowType::Toplevel);
+        window.set_title("opensi editor");
+        window.set_property_default_width(640);
+        window.set_property_default_height(480);
+
+        window.show_all();
+
+        connect!(
+            relm,
+            window,
+            connect_delete_event(_, _),
+            return (Some(Msg::Quit), Inhibit(false))
+        );
+
+        window.show_all();
+
+        Win {
+            model,
+            widgets: Widgets { window: window },
+        }
+    }
+}
+
+fn main() {
+    Win::run(()).expect("run failed");
+}

--- a/src/bin/editor.rs
+++ b/src/bin/editor.rs
@@ -51,8 +51,6 @@ impl Widget for Win {
         window.set_property_default_width(640);
         window.set_property_default_height(480);
 
-        window.show_all();
-
         connect!(
             relm,
             window,


### PR DESCRIPTION
После длительных метаний подключил [relm](https://github.com/antoyo/relm/) для рисования GUI редактора. Проверить окошко можно командой `cargo run --bin editor`.